### PR TITLE
recreated the alb and modified development.rb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,6 +75,6 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   #config.hosts << "app_server"
-  config.hosts << "test-alb-2017183245.ap-northeast-1.elb.amazonaws.com"
+  config.hosts << "test-alb-1619924071.ap-northeast-1.elb.amazonaws.com"
   
 end


### PR DESCRIPTION
# 第6回課題提出
## 課題およびALB再作成に伴うdevelopment.rbの変更報告

### 課題内容
* CloudTrailのイベント内容
  * イベント名:StartDBInstance (DBインスタンスの起動リクエスト)
  * イベント情報(3つピックアップ):
    - SourceIPAddress:リクエストの送信元IP
    - eventName:実行したイベント内容
![CloudTrail(イベント名と送信元IP)](https://user-images.githubusercontent.com/88648453/227774337-367d6f76-3459-4221-9310-6dbfc57b2c7d.png)
    - responseElements:DBインスタンスの起動リクエストに対するレスポンスの内容
      - dbInstanceStatus:starting(DBインスタンスのステータス)
      
![CloudTrail(DBインスタンスステータス)](https://user-images.githubusercontent.com/88648453/227774464-b5664474-0861-411c-a59c-f2ca052a498f.png)

![CloudTrail(詳細)](https://user-images.githubusercontent.com/88648453/227774385-4f9e6cf1-9e48-43e2-8092-88510f8e8fb9.png)


* ALBのメトリクス監視(UnhealthyHostCountを監視)
  1. Rails停止後(ALBヘルスチェック) 
     ![Rails停止後(ALBヘルスチェック)](https://user-images.githubusercontent.com/88648453/227757969-65e561a7-dc22-4e43-8551-efebd0b59b58.png)
  2. Rails停止後(CloudWatchアラーム状態)　→UnhealthyHostCount>=1を満たす
![Rails停止後(CloudWatchアラーム状態)](https://user-images.githubusercontent.com/88648453/227758002-636e5c47-8b0f-4e5b-9f23-3a54e1636e21.png)
  3. Rails停止後(CloudWatchアラーム通知) 
![Rails停止後(CloudWatchアラーム通知)](https://user-images.githubusercontent.com/88648453/227758059-781b79f0-73fd-4433-99f7-8ef38be8e7c4.png)
  4. Rails起動後(ALBヘルスチェック)
![Rails起動後(ALBヘルスチェック)](https://user-images.githubusercontent.com/88648453/227758101-f018f9d5-a908-465a-b4d8-fd77a25590c2.png)
  5. Rails起動後(CloudWatch OK状態)　→UnhealthyHostCount>=1から外れる
![Rails起動後(CloudWatchアラーム状態)](https://user-images.githubusercontent.com/88648453/227758141-597a8849-f958-44d2-8609-844b95b78420.png)
  6. Rails起動後(CloudWatch OK通知)
![Rails起動後(CloudWatchアラーム通知)](https://user-images.githubusercontent.com/88648453/227758180-bc95013e-eb52-4819-9aea-e803d7c929e7.png)

* Rails環境のAWS月額見積
   *  https://calculator.aws/#/estimate?id=9e9856ce253adb25849f9ec59bc150aa888b3707
   * 前提条件
     - オンデマンド料金、730時間/月稼働を前提としています
     - EC2通信料はリージョン内10GB/月としています
     - S3はALBアクセスログを保管する想定で見積っています
     - CloudWatchはALBメトリクス1つを監視する想定で見積っています

* 先月のEC2料金
  *  Cost Explorerでサービスを「EC2」、「EC2 Other」で抽出して2月分のEC2月額料金を調べた
  * 請求書に記載の料金と一致することを確認した
    ※当アカウントは無料枠はすでに終了

* ALB再作成に伴うファイルの変更
  * config/development.rbにて、「config.host」を編集 


* その他の学習
  * 目的：PumaもしくはNginxを止めることでHTTPエラーの内容を確認したかった 
  * Pumaを停止した場合：
	* ヘルスチェック：
		Unhealthy
	* レスポンス：
		ALB←Nginx（HTTP502 error、railsで指定した500.htmlページが表示される)　
	* 状況：
		ALB→Nginxまでは通信がいくが、Pumaから応答がない
　　　		Nginxの設定ファイルを見ると、5XXerror時は500.htmlのページが返されるようになっている
		この場合はHTTPCode_Target_5XX_Countメトリクスがカウントされる
		HTTPCode_ELB_5XX_Countはカウントされない（ALBが発行したerrorではないため）

	* Nginxログ：
		10.1.0.143 - - [25/Mar/2023:05:48:25 +0000] "GET / HTTP/1.1" 502 1635 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) 	AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"　（クライアントがALB経由でNginxにアクセス） 

  * Nginxを停止した場合：
	* ヘルスチェック：
		Unhealthy
	* レスポンス：
		クライアント←ALB（HTTP502 error、502 Bad Gatewayの表示のみ)
	* 状況：
		ALBからターゲット（Nginx）に通信が行っているが、Nginxから応答が返ってこないので
		ALBがerrorを発行してクライアントに送信する
		HTTPCode_ELB_5XX_Count、正確にはHTTPCode_ELB_502_Countがカウントされる

	* ALBログ:
		http 2023-03-25T06:01:25.989222Z app/test-alb/f6ca72fc68390a86 x.x.x.x:xxxxx 10.1.0.60:80 -1 -1 -1 502 - 502 679 "GET 
		http://test-alb-1619924071.ap-northeast-1.elb.amazonaws.com:80/ HTTP/1.1" 

		→8~10カラムの「-1 502 -」は詳細は以下
			"response_processing_time" が "-1": ターゲットがアイドルタイムアウト前に接続を閉じた
			"elb_status_code" が "502":ALB がステータスコード 502 を返している
			"target_status_code" が "-": ターゲットが応答を返していない
